### PR TITLE
fixing a blocking redis command hang

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -113,8 +113,6 @@ class Connection(object):
           callback(None)
         self.read_callbacks = []
 
-
-
     def disconnect(self):
         if self._stream:
             s = self._stream


### PR DESCRIPTION
i noticed it was hanging on read_until.   to solve this, i added an on_error_callback on the tornado iostream:

http://www.tornadoweb.org/documentation/_modules/tornado/iostream.html#IOStream.set_close_callback

and had it call the wrapped read_until callback(s) with no data if the socket closes.  

the clients are then able to catch this exception using a tornado exception stack context and handle appropriately.

How to repro:
if you have a brpoplpush call being yielded and the redis server goes down, the callback is never called (even if you bring the redis server back up)
