### PR TITLE
catch raised IOError in execute_command so as to not prevent future calls from hanging

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -420,7 +420,12 @@ class Client(object):
         if (cmd in PUB_SUB_COMMANDS) or (self.subscribed and cmd == 'PUBLISH'):
             result = True
         else:
-            data = yield gen.Task(self.connection.readline)
+            data = None
+            try:
+                data = yield gen.Task(self.connection.readline)
+            except ConnectionError, _:
+                pass # If IOError is raised inside readline, data will be None
+
             if not data:
                 result = None
                 self.connection.read_done()


### PR DESCRIPTION
it seemed that when an IOError is caught and the on_disconnect event is fired, the resulting exception caused the control flow to leave execute_command (and be caught in the client).  this prevented on_read_done from being called, and future calls to queue_wait would only append to the read queue (as self.in_progress would stay True)

not sure if this is the best change to address the issue.
