### PR TITLE
add scripting support

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -944,26 +944,38 @@ class Client(object):
         self.execute_command('UNWATCH', callback=callback)
 
     ### SCRIPTING COMMANDS
-    def eval(self, script, keys, args, callback=None):
+    def eval(self, script, keys=None, args=None, callback=None):
+        if keys is None:
+            keys = []
+        if args is None:
+            args = []
         num_keys = len(keys)
         keys.extend(args)
         self.execute_command('EVAL', script, num_keys, *keys, callback=callback)
 
-    def evalsha(self, shahash, keys, args, callback=None):
+    def evalsha(self, shahash, keys=None, args=None, callback=None):
+        if keys is None:
+            keys = []
+        if args is None:
+            args = []
         num_keys = len(keys)
         keys.extend(args)
         self.execute_command('EVALSHA', shahash, num_keys, *keys, callback=callback)
 
     def script_exists(self, shahashes, callback=None):
+        # not yet implemented in the redis protocol
         self.execute_command('SCRIPT EXISTS', *shahashes, callback=callback)
 
     def script_flush(self, callback=None):
-        self.execute_command('SCRIPT FLUSH', callback=callback)
+        # not yet implemented in the redis protocol
+        self.execute_command('SCRIPT FLUSH', callback=callback, verbose=True)
 
     def script_kill(self, callback=None):
+        # not yet implemented in the redis protocol
         self.execute_command('SCRIPT KILL', callback=callback)
 
     def script_load(self, script, callback=None):
+        # not yet implemented in the redis protocol
         self.execute_command('SCRIPT LOAD', script, callback=callback)
 
 class Pipeline(Client):

--- a/tornadoredis/tests/__init__.py
+++ b/tornadoredis/tests/__init__.py
@@ -2,6 +2,7 @@ import unittest
 from server_commands import ServerCommandsTestCase
 from pubsub import PubSubTestCase
 from pipeline import PipelineTestCase
+from scripting import ScriptingTestCase
 # from reconnect import ReconnectTestCase
 
 
@@ -10,6 +11,7 @@ def all_tests():
     suite.addTest(unittest.makeSuite(ServerCommandsTestCase,
                                      PubSubTestCase,
                                      PipelineTestCase,
+                                     ScriptingTestCase,
                                      # ReconnectTestCase,
                                      ))
     return suite

--- a/tornadoredis/tests/scripting.py
+++ b/tornadoredis/tests/scripting.py
@@ -1,0 +1,23 @@
+import hashlib
+import logging
+from tornado import gen
+
+from redistest import RedisTestCase, async_test
+
+
+class ScriptingTestCase(RedisTestCase):
+
+    @async_test
+    @gen.engine
+    def test_eval(self):
+        script = 'return 2'
+        script_digest = hashlib.sha1(script).hexdigest()
+
+        results = yield gen.Task(self.client.eval, script)
+        self.assertEqual(2, results)
+
+        # test evalsha
+        results = yield gen.Task(self.client.evalsha, script_digest)
+        self.assertEqual(2, results)
+
+        self.stop()


### PR DESCRIPTION
redis 2.6 is at RC3 and has scripting support.

The redis protocol as of RC3 supports EVAL and EVALSHA. Those two functions, along with other scripting options, are included in this pull request.

Other scripting commands, such as SCRIPT FLUSH, SCRIPT EXISTS etc... haven't been added yet to the protocol but work on the command-line as well as via telnet.
