### PR TITLE
client.delete should accept multiple keys

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -565,8 +565,8 @@ class Client(object):
     def substr(self, key, start, end, callback=None):
         self.execute_command('SUBSTR', key, start, end, callback=callback)
 
-    def delete(self, key, callback=None):
-        self.execute_command('DEL', key, callback=callback)
+    def delete(self, *keys, **kwargs):
+        self.execute_command('DEL', *keys, callback=kwargs.get('callback'))
 
     def set(self, key, value, callback=None):
         self.execute_command('SET', key, value, callback=callback)

--- a/tornadoredis/tests/server_commands.py
+++ b/tornadoredis/tests/server_commands.py
@@ -28,6 +28,21 @@ class ServerCommandsTestCase(RedisTestCase):
 
     @async_test
     @gen.engine
+    def test_delete(self):
+        res = yield gen.Task(self.client.mset, {'a': 1, 'b': 2, 'c': 3})
+        res = yield gen.Task(self.client.delete, 'a')
+        res = yield gen.Task(self.client.exists, 'a')
+        self.assertEqual(res, False)
+
+        res = yield gen.Task(self.client.delete, 'b', 'c')
+        res = yield gen.Task(self.client.exists, 'b')
+        self.assertEqual(res, False)
+        res = yield gen.Task(self.client.exists, 'c')
+        self.assertEqual(res, False)
+        self.stop()
+
+    @async_test
+    @gen.engine
     def test_setex(self):
         res = yield gen.Task(self.client.setex, 'foo', 5, 'bar')
         self.assertEqual(res, True)


### PR DESCRIPTION
This patch add support for multiple keys deletion at once. See http://redis.io/commands/del
