### PR TITLE
Fixed incorrect Message.channel / Message.pattern assignment

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -29,7 +29,7 @@ class Message(object):
             (self.kind, self.channel, self.body) = args
             self.pattern = self.channel
         elif len(args) == 4:
-            (self.kind, self.channel, self.pattern, self.body) = args
+            (self.kind, self.pattern, self.channel, self.body) = args
         else:
             raise ValueError('Invalid number of arguments')
 


### PR DESCRIPTION
Before this fix, the pattern would incorrectly get assigned to `message.channel` and the channel to  `message.pattern`.

> The type of the message is pmessage: it is a message received as result of a PUBLISH command issued by another client, matching a pattern-matching subscription. **The second element is the original pattern matched, the third element is the name of the originating channel,** and the last element the actual message payload.

http://redis.io/topics/pubsub
