### PR TITLE
Reset connection password on disconnect

### DIFF
--- a/tornadoredis/connection.py
+++ b/tornadoredis/connection.py
@@ -26,7 +26,7 @@ class Connection(object):
         self.read_callbacks = []
         self.ready_callbacks = deque()
         self._lock = 0
-        self.info = {'db': 0}
+        self.info = {'db': 0, 'pass': None}
 
     def __del__(self):
         self.disconnect()
@@ -67,6 +67,7 @@ class Connection(object):
                 self._stream = IOStream(sock, io_loop=self._io_loop)
                 self._stream.set_close_callback(self.on_stream_close)
                 self.info['db'] = 0
+                self.info['pass'] = None
             except socket.error, e:
                 raise ConnectionError(str(e))
             self.fire_event('on_connect')


### PR DESCRIPTION
This is a fix for re-connecting to a password-protected server; it
allows the AUTH command to be re-sent correctly on a re-connect.
