### PR TITLE
Removed unicode encoding for strings that might not be unicode

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -12,7 +12,7 @@ import time as mod_time
 from tornado.ioloop import IOLoop
 from tornado import gen
 from tornado import stack_context
-from tornado.escape import utf8, to_unicode, to_basestring
+from tornado.escape import utf8, to_basestring
 
 from .exceptions import RequestError, ConnectionError, ResponseError
 from .connection import Connection
@@ -440,7 +440,6 @@ class Client(object):
         if not response:
             raise ResponseError('EmptyResponse')
         else:
-            response = to_unicode(response)
             response = response[:-2]
         callback(response)
 


### PR DESCRIPTION
Reverted where the code was attempting to unicode encode a value pulled from redis. The to_unicode would cause an exception to be thrown if there was a multibulk reply (eg. HMGET myhash field1 field2) and the values stored in redis were not unicode data - ie. gzip data.
