### PR TITLE
Version 2.4.5: added support for Locks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-VERSION = '2.4.14'
+VERSION = '2.4.15'
 
 setup(name='tornado-redis',
       version=VERSION,

--- a/tornadoredis/exceptions.py
+++ b/tornadoredis/exceptions.py
@@ -42,3 +42,8 @@ class ResponseError(RedisError):
 
 class InvalidResponse(RedisError):
     pass
+
+class LockError(RedisError):
+    "Errors thrown from the Lock"
+    pass
+

--- a/tornadoredis/tests/test_locks.py
+++ b/tornadoredis/tests/test_locks.py
@@ -1,0 +1,41 @@
+from tornado.gen import engine, Task
+from .redistest import RedisTestCase, async_test
+
+
+class LocksTestCase(RedisTestCase):
+
+    @async_test
+    @engine
+    def test_locks(self):
+
+        '''
+        The idea of this test is simple:
+        1. Acquire a lock using a Lock object.
+        2. See that trying to acquire it with a different Lock object fails, if blocking=False.
+        3. Try to acquire it, with blocking=True. Release it in the first Lock to see that the acquiring succeeds.
+        '''
+
+        print "Trying to get the lock"
+        my_lock = self.client.lock("testLock", lock_ttl=10, polling_interval=0.1)
+        print "Acquiring..."
+        result = yield Task(my_lock.acquire, blocking=True)
+        print "Result: %s (should be True)" % result
+        self.assertEqual(result, True)
+
+        print "Trying to get the lock again with a different Lock"
+        my_lock2 = self.client.lock("testLock", lock_ttl=10, polling_interval=0.1)
+        print "Acquiring..."
+        result = yield Task(my_lock2.acquire, blocking=False)
+        print "Result: %s (should be False)" % result
+        self.assertEqual(result, False)
+
+        print "Trying to acquire and release at the same time..."
+        self.io_loop.add_timeout(self.io_loop.time() + 1, my_lock.release)
+        result = yield Task(my_lock2.acquire, blocking=True)
+        print "Result: %s (should be True)" % result
+        self.assertEqual(result, True)
+
+        yield Task(my_lock2.release)
+        print "Released!"
+
+        self.stop()


### PR DESCRIPTION
I added support for Redis locks, with an async version of the interface as found in redis-py (https://github.com/andymccurdy/redis-py/blob/master/redis/client.py).

We have used it on Production servers here in Ev.me for the last few months.
