### PR TITLE
fix keys arg in eval command

### DIFF
--- a/tornadoredis/client.py
+++ b/tornadoredis/client.py
@@ -1205,9 +1205,9 @@ class Client(object):
         if args is None:
             args = []
         num_keys = len(keys)
-        keys.extend(args)
+        _args = keys + args
         self.execute_command('EVAL', script, num_keys,
-                             *keys, callback=callback)
+                             *_args, callback=callback)
 
     def evalsha(self, shahash, keys=None, args=None, callback=None):
         if keys is None:

--- a/tornadoredis/tests/test_scripting.py
+++ b/tornadoredis/tests/test_scripting.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 from tornado import gen
 
@@ -22,3 +23,32 @@ class ScriptingTestCase(RedisTestCase):
         self.stop()
 
     # TODO: script_exists, script_load, script_flush, script_kill
+    @async_test
+    @gen.engine
+    def test_eval_with_args(self):
+        key, value = 'test:key:eval', 'value:eval'
+        # make sure that key does not exists
+        yield gen.Task(self.client.delete, key)
+
+        script = """
+        if redis.call('SETNX', KEYS[1], ARGV[1])==1
+        then
+            return 'foo'
+        else
+            return 'bar'
+        end
+        """
+        keys = [key]
+        _keys_copy = copy.deepcopy(keys)
+        args = [value]
+
+        results = yield gen.Task(self.client.eval, script, keys, args)
+        self.assertEqual('foo', results)
+        # compare keys after eval command and initial keys (_keys_copy)
+        # to make sure that *eval* command does not change keys list
+        self.assertEqual(keys, _keys_copy)
+        results = yield gen.Task(self.client.eval, script, keys, args)
+        self.assertEqual('bar', results)
+        self.assertEqual(keys, _keys_copy)
+
+        self.stop()


### PR DESCRIPTION
Hi Vlad!
I've noticed that `eval` command has undesired behavior:

``` python
keys = ['key1', 'key2']
args = ['arg1', 'arg2']
yield gen.Task(self.client.eval, script, keys, args)
print(keys)
>>> ['key1', 'key2', 'arg1', 'arg2']
```

since `keys` is mutable list, any changes inside `eval` command affect outside `keys` variable. 
so here patch and test to fix this issue. 
Please review. 
