### PR TITLE
Fix bug where the BaseSubscriber would throw an error if the redis connection is closed

### DIFF
--- a/tornadoredis/pubsub.py
+++ b/tornadoredis/pubsub.py
@@ -114,7 +114,7 @@ class BaseSubscriber(object):
         Clears subscriber lists and counters.
         """
         for channel_name, subscribers in self.subscriber_count.items():
-            if subscribers:
+            if subscribers and self.redis.connection.connected():
                 self.redis.unsubscribe(channel_name)
         self.subscribers = defaultdict(Counter)
         self.subscriber_count = Counter()


### PR DESCRIPTION
the `close` function on BaseSubscriber would never be called is a disconnect occur from the redis server being closed
