### PR TITLE
Fix test_object test failure

### DIFF
--- a/tornadoredis/tests/test_commands.py
+++ b/tornadoredis/tests/test_commands.py
@@ -1053,6 +1053,9 @@ class ServerCommandsTestCase(RedisTestCase):
         self.assertEqual(t, 'int')
         yield gen.Task(self.client.set, 'foo', 's')
         t = yield gen.Task(self.client.object, 'encoding', 'foo')
+        self.assertEqual(t, 'embstr')
+        yield gen.Task(self.client.set, 'foo', 'Long, long, long ago there lived a king ...')
+        t = yield gen.Task(self.client.object, 'encoding', 'foo')
         self.assertEqual(t, 'raw')
 
         self.stop()

--- a/tornadoredis/tests/test_ipv6.py
+++ b/tornadoredis/tests/test_ipv6.py
@@ -11,5 +11,4 @@ class Ipv6ConnectionTestCase(RedisTestCase):
         except tornadoredis.exceptions.ConnectionError as e:
             msg, = e.args
             bad_error = '[Errno -9] Address family for hostname not supported'
-            self.assertNotEquals(bad_error, msg)
-
+            self.assertNotEqual(bad_error, msg)


### PR DESCRIPTION
A string shorter than 39 bytes will be stored as `embstr` encoding.