### PR TITLE
Don't execute FLUSHDB when run test_pubsub

### DIFF
--- a/tornadoredis/tests/redistest.py
+++ b/tornadoredis/tests/redistest.py
@@ -86,10 +86,11 @@ class RedisTestCase(AsyncTestCase):
                 standardMsg = '%s not less than or equal to %s' % (safe_repr(a), safe_repr(b))
                 self.fail(self._formatMessage(msg, standardMsg))
 
-    def setUp(self):
+    def setUp(self, flush=True):
         super(RedisTestCase, self).setUp()
         self.client = self._new_client()
-        self.client.flushdb()
+        if flush:
+            self.client.flushdb()
 
     def tearDown(self):
         try:

--- a/tornadoredis/tests/test_pubsub.py
+++ b/tornadoredis/tests/test_pubsub.py
@@ -11,7 +11,7 @@ from tornadoredis.pubsub import SockJSSubscriber, SocketIOSubscriber
 class PubSubTestCase(RedisTestCase):
 
     def setUp(self):
-        super(PubSubTestCase, self).setUp()
+        super(PubSubTestCase, self).setUp(flush=False)
         self._message_count = 0
         self.publisher = self._new_client()
 


### PR DESCRIPTION
The reason why test_pubsub fail is that testcase will send a (P)SUBSCRIBE command before FLUSHDB. But in a (P)SUBSCRIBE context, only few commands can be executed including (P)SUBSCRIBE / (P)UNSUBSCRIBE / QUIT. On the other hand, there is no need to flushdb when testing pub/sub. So I add a flush option to the setUp function.