### PR TITLE
Prevent leaking memory when calling `disconnect`

### DIFF
--- a/tornadoredis/connection.py
+++ b/tornadoredis/connection.py
@@ -89,6 +89,11 @@ class Connection(object):
                 callback()
 
     def disconnect(self):
+        callbacks = self.read_callbacks
+        self.read_callbacks = set()
+        for callback in callbacks:
+            callback()
+
         if self._stream:
             s = self._stream
             self._stream = None


### PR DESCRIPTION
With the linked gist [0], before this change, leaking memory/connection
objects was trivial in only tens of connections opening and closing.

After the gist, we no longer leak any memory.

I am not entirely sure if this is the optimal solution, or if there are
other places where similar logic is required, but it fixes my particular
problem.

[0] https://gist.github.com/AeroNotix/c2b13cddd1f48a72b6c1
